### PR TITLE
Macos fixes

### DIFF
--- a/git-rpm-version
+++ b/git-rpm-version
@@ -71,9 +71,9 @@ function version() {
             # Remove release candidate; it will change the rpm release instead
             sed -e 's/-rc[0-9]*//' |
             # Remove git hash; it will change the rpm release instead
-            sed -e 's/-[0-9]\+-g[0-9a-f]\+//' |
+            sed -e 's/-[0-9]\{1,\}-g[0-9a-f]\{1,\}//' |
             # '-' is disallowed in rpm versions; replace all '-' with '.'
-            sed -e 's/-/./g'
+            sed -e 's/-/\./g'
     else
         # Use a version of 0 if no release tag is found
         echo 0
@@ -95,7 +95,7 @@ function release() {
     fi
     if [ ${git_describe:0:1} = v ]; then
         # Remove the version
-        no_version=$(echo "$git_describe" | sed -e 's/[^-]\+//')
+        no_version=$(echo "$git_describe" | sed -e 's/[^-]\{1,\}//')
         if [ -z "${git_describe##*rc*}" ]; then
             # Release candidate
             release="0$no_version"

--- a/test/run-tests
+++ b/test/run-tests
@@ -3,7 +3,7 @@
 . ./assert.sh/assert.sh
 
 testdir=$(pwd)
-gitrpmversion=$(readlink -m "$testdir"/../git-rpm-version)
+gitrpmversion="${testdir}/../git-rpm-version"
 
 for test in "$testdir"/test-*; do
     tempdir=$(mktemp -d)


### PR DESCRIPTION
Those fixes allow git-rpm-version to work on Darwin/Macos Mojave