### PR TITLE
Fix git-rpm-version behaviour with semver2.0.0 Release Candidate numbering

### DIFF
--- a/git-rpm-version
+++ b/git-rpm-version
@@ -69,7 +69,7 @@ function version() {
             # Remove leading 'v'
             sed -e 's/v//' |
             # Remove release candidate; it will change the rpm release instead
-            sed -e 's/-rc[0-9]*//' |
+            sed -e 's/-rc\.*[0-9]*//' |
             # Remove git hash; it will change the rpm release instead
             sed -e 's/-[0-9]\{1,\}-g[0-9a-f]\{1,\}//' |
             # '-' is disallowed in rpm versions; replace all '-' with '.'
@@ -94,8 +94,8 @@ function release() {
         exit 1
     fi
     if [ ${git_describe:0:1} = v ]; then
-        # Remove the version
-        no_version=$(echo "$git_describe" | sed -e 's/[^-]\{1,\}//')
+        # Remove the version and massage semver 2.0.0 rc.X to semver 1.0.0 rcX
+        no_version=$(echo "$git_describe" | sed -e 's/[^-]\{1,\}//' -e 's/rc\./rc/')
         if [ -z "${git_describe##*rc*}" ]; then
             # Release candidate
             release="0$no_version"

--- a/git-rpm-version
+++ b/git-rpm-version
@@ -94,8 +94,8 @@ function release() {
         exit 1
     fi
     if [ ${git_describe:0:1} = v ]; then
-        # Remove the version and massage semver 2.0.0 rc.X to semver 1.0.0 rcX
-        no_version=$(echo "$git_describe" | sed -e 's/[^-]\{1,\}//' -e 's/rc\./rc/')
+        # Remove the version
+        no_version=$(echo "$git_describe" | sed -e 's/[^-]\{1,\}//')
         if [ -z "${git_describe##*rc*}" ]; then
             # Release candidate
             release="0$no_version"

--- a/test/test-ahead-of-release-candidate-semver2
+++ b/test/test-ahead-of-release-candidate-semver2
@@ -18,7 +18,7 @@ unset GIT_COMMITTER_DATE
 
 assert_raises "$gitrpmversion"
 assert_raises "$gitrpmversion -h"
-assert "$gitrpmversion -r" "0.rc4.1.gca4a874"
+assert "$gitrpmversion -r" "0.rc.4.1.gca4a874"
 assert "$gitrpmversion -v" "1.2.3"
-assert "$gitrpmversion -rv" "1.2.3\n0.rc4.1.gca4a874"
-assert "$gitrpmversion -vr" "1.2.3\n0.rc4.1.gca4a874"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc.4.1.gca4a874"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc.4.1.gca4a874"

--- a/test/test-ahead-of-release-candidate-semver2
+++ b/test/test-ahead-of-release-candidate-semver2
@@ -1,0 +1,24 @@
+git init >/dev/null
+# Specify everything so that the commit hash will be the same every time
+export GIT_AUTHOR_NAME="foo"
+export GIT_COMMITTER_NAME="foo"
+export GIT_AUTHOR_EMAIL="foo@example.com"
+export GIT_COMMITTER_EMAIL="foo@example.com"
+export GIT_AUTHOR_DATE="1970-01-01T00:00:00+0000"
+export GIT_COMMITTER_DATE="1970-01-01T00:00:00+0000"
+git commit --allow-empty -m 'A' >/dev/null
+git tag -a -m 'v1.2.3-rc.4' v1.2.3-rc.4
+git commit --allow-empty -m 'B' >/dev/null
+unset GIT_AUTHOR_NAME
+unset GIT_COMMITTER_NAME
+unset GIT_AUTHOR_EMAIL
+unset GIT_COMMITTER_EMAIL
+unset GIT_AUTHOR_DATE
+unset GIT_COMMITTER_DATE
+
+assert_raises "$gitrpmversion"
+assert_raises "$gitrpmversion -h"
+assert "$gitrpmversion -r" "0.rc4.1.gca4a874"
+assert "$gitrpmversion -v" "1.2.3"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc4.1.gca4a874"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc4.1.gca4a874"

--- a/test/test-dirty-ahead-of-release-candidate-semver2
+++ b/test/test-dirty-ahead-of-release-candidate-semver2
@@ -1,0 +1,27 @@
+git init >/dev/null
+# Specify everything so that the commit hash will be the same every time
+export GIT_AUTHOR_NAME="foo"
+export GIT_COMMITTER_NAME="foo"
+export GIT_AUTHOR_EMAIL="foo@example.com"
+export GIT_COMMITTER_EMAIL="foo@example.com"
+export GIT_AUTHOR_DATE="1970-01-01T00:00:00+0000"
+export GIT_COMMITTER_DATE="1970-01-01T00:00:00+0000"
+git commit --allow-empty -m 'A' >/dev/null
+git tag -a -m 'v1.2.3-rc.4' v1.2.3-rc.4
+touch README
+git add README
+git commit -m 'B' >/dev/null
+echo foo > README
+unset GIT_AUTHOR_NAME
+unset GIT_COMMITTER_NAME
+unset GIT_AUTHOR_EMAIL
+unset GIT_COMMITTER_EMAIL
+unset GIT_AUTHOR_DATE
+unset GIT_COMMITTER_DATE
+
+assert_raises "$gitrpmversion"
+assert_raises "$gitrpmversion -h"
+assert "$gitrpmversion -r" "0.rc4.1.g85d1319.dirty"
+assert "$gitrpmversion -v" "1.2.3"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc4.1.g85d1319.dirty"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc4.1.g85d1319.dirty"

--- a/test/test-dirty-ahead-of-release-candidate-semver2
+++ b/test/test-dirty-ahead-of-release-candidate-semver2
@@ -21,7 +21,7 @@ unset GIT_COMMITTER_DATE
 
 assert_raises "$gitrpmversion"
 assert_raises "$gitrpmversion -h"
-assert "$gitrpmversion -r" "0.rc4.1.g85d1319.dirty"
+assert "$gitrpmversion -r" "0.rc.4.1.g85d1319.dirty"
 assert "$gitrpmversion -v" "1.2.3"
-assert "$gitrpmversion -rv" "1.2.3\n0.rc4.1.g85d1319.dirty"
-assert "$gitrpmversion -vr" "1.2.3\n0.rc4.1.g85d1319.dirty"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc.4.1.g85d1319.dirty"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc.4.1.g85d1319.dirty"

--- a/test/test-dirty-release-candidate-semver2
+++ b/test/test-dirty-release-candidate-semver2
@@ -20,7 +20,7 @@ unset GIT_COMMITTER_DATE
 
 assert_raises "$gitrpmversion"
 assert_raises "$gitrpmversion -h"
-assert "$gitrpmversion -r" "0.rc4.dirty"
+assert "$gitrpmversion -r" "0.rc.4.dirty"
 assert "$gitrpmversion -v" "1.2.3"
-assert "$gitrpmversion -rv" "1.2.3\n0.rc4.dirty"
-assert "$gitrpmversion -vr" "1.2.3\n0.rc4.dirty"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc.4.dirty"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc.4.dirty"

--- a/test/test-dirty-release-candidate-semver2
+++ b/test/test-dirty-release-candidate-semver2
@@ -1,0 +1,26 @@
+git init >/dev/null
+# Specify everything so that the commit hash will be the same every time
+export GIT_AUTHOR_NAME="foo"
+export GIT_COMMITTER_NAME="foo"
+export GIT_AUTHOR_EMAIL="foo@example.com"
+export GIT_COMMITTER_EMAIL="foo@example.com"
+export GIT_AUTHOR_DATE="1970-01-01T00:00:00+0000"
+export GIT_COMMITTER_DATE="1970-01-01T00:00:00+0000"
+touch README
+git add README
+git commit -m 'A' >/dev/null
+git tag -a -m 'v1.2.3-rc.4' v1.2.3-rc.4
+echo foo > README
+unset GIT_AUTHOR_NAME
+unset GIT_COMMITTER_NAME
+unset GIT_AUTHOR_EMAIL
+unset GIT_COMMITTER_EMAIL
+unset GIT_AUTHOR_DATE
+unset GIT_COMMITTER_DATE
+
+assert_raises "$gitrpmversion"
+assert_raises "$gitrpmversion -h"
+assert "$gitrpmversion -r" "0.rc4.dirty"
+assert "$gitrpmversion -v" "1.2.3"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc4.dirty"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc4.dirty"

--- a/test/test-promoted-release-candidate-semver2
+++ b/test/test-promoted-release-candidate-semver2
@@ -1,0 +1,26 @@
+git init >/dev/null
+# Specify everything so that the commit hash will be the same every time
+export GIT_AUTHOR_NAME="foo"
+export GIT_COMMITTER_NAME="foo"
+export GIT_AUTHOR_EMAIL="foo@example.com"
+export GIT_COMMITTER_EMAIL="foo@example.com"
+export GIT_AUTHOR_DATE="1970-01-01T00:00:00+0000"
+export GIT_COMMITTER_DATE="1970-01-01T00:00:00+0000"
+git commit --allow-empty -m 'A' >/dev/null
+git tag -a -m 'v1.2.3-rc.4' v1.2.3-rc.4
+export GIT_AUTHOR_DATE="1970-01-02T00:00:00+0000"
+export GIT_COMMITTER_DATE="1970-01-02T00:00:00+0000"
+git tag -a -m 'v1.2.3' v1.2.3
+unset GIT_AUTHOR_NAME
+unset GIT_COMMITTER_NAME
+unset GIT_AUTHOR_EMAIL
+unset GIT_COMMITTER_EMAIL
+unset GIT_AUTHOR_DATE
+unset GIT_COMMITTER_DATE
+
+assert_raises "$gitrpmversion"
+assert_raises "$gitrpmversion -h"
+assert "$gitrpmversion -r" "1"
+assert "$gitrpmversion -v" "1.2.3"
+assert "$gitrpmversion -rv" "1.2.3\n1"
+assert "$gitrpmversion -vr" "1.2.3\n1"

--- a/test/test-release-candidate-semver2
+++ b/test/test-release-candidate-semver2
@@ -17,7 +17,7 @@ unset GIT_COMMITTER_DATE
 
 assert_raises "$gitrpmversion"
 assert_raises "$gitrpmversion -h"
-assert "$gitrpmversion -r" "0.rc4"
+assert "$gitrpmversion -r" "0.rc.4"
 assert "$gitrpmversion -v" "1.2.3"
-assert "$gitrpmversion -rv" "1.2.3\n0.rc4"
-assert "$gitrpmversion -vr" "1.2.3\n0.rc4"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc.4"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc.4"

--- a/test/test-release-candidate-semver2
+++ b/test/test-release-candidate-semver2
@@ -1,0 +1,23 @@
+git init >/dev/null
+# Specify everything so that the commit hash will be the same every time
+export GIT_AUTHOR_NAME="foo"
+export GIT_COMMITTER_NAME="foo"
+export GIT_AUTHOR_EMAIL="foo@example.com"
+export GIT_COMMITTER_EMAIL="foo@example.com"
+export GIT_AUTHOR_DATE="1970-01-01T00:00:00+0000"
+export GIT_COMMITTER_DATE="1970-01-01T00:00:00+0000"
+git commit --allow-empty -m 'A' >/dev/null
+git tag -a -m 'v1.2.3-rc.4' v1.2.3-rc.4
+unset GIT_AUTHOR_NAME
+unset GIT_COMMITTER_NAME
+unset GIT_AUTHOR_EMAIL
+unset GIT_COMMITTER_EMAIL
+unset GIT_AUTHOR_DATE
+unset GIT_COMMITTER_DATE
+
+assert_raises "$gitrpmversion"
+assert_raises "$gitrpmversion -h"
+assert "$gitrpmversion -r" "0.rc4"
+assert "$gitrpmversion -v" "1.2.3"
+assert "$gitrpmversion -rv" "1.2.3\n0.rc4"
+assert "$gitrpmversion -vr" "1.2.3\n0.rc4"


### PR DESCRIPTION
Semver 2.0.0 has changed the way Release Candidates are numbered, and introduced a '.' between 'rc' and the number.

This PR aims at making `git-rpm-version` compatible with this new scheme.